### PR TITLE
tinker(idea) try warm-up manually

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -54,6 +54,8 @@ tasks:
       ## behat END ##
       # initiate phpunit  
       ddev php public/admin/tool/phpunit/cli/init.php
+      # manually warmup index (since .gitpod phpstorm-prebuild key seems not working)
+      /ide-desktop/phpstorm-latest/backend/bin/remote-dev-server warm-up /workspace/moodle-by-php-drupal-ddev-2
     command: |
       yes| ddev start
       # PREBUILD problem - url at config.php will be the old prebuild workspace url, hence must append every time we start


### PR DESCRIPTION
### **User description**
@CodiumAI-Agent /review


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added a command in `.gitpod.yml` to manually warm up the index for PHPStorm due to issues with the prebuild key.
- Included a comment to explain the necessity of the manual warm-up.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.gitpod.yml</strong><dd><code>Add manual index warm-up command in Gitpod configuration</code>&nbsp; </dd></summary>
<hr>
      
.gitpod.yml

<li>Added a command to manually warm up the index for PHPStorm.<br> <li> Included a comment explaining the reason for the manual warm-up.<br>


</details>
    

  </td>
  <td><a href="https://github.com/TmEuMail-2020/moodle-by-php-drupal-ddev-2/pull/1/files#diff-370a022e48cb18faf98122794ffc5ce775b2606b09a9d1f80b71333425ec078e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

